### PR TITLE
use OFW_FWD macro

### DIFF
--- a/include/kumi.hpp
+++ b/include/kumi.hpp
@@ -9,6 +9,8 @@
 #include <utility>
 #include <ostream>
 
+#define OFW_FWD(...) static_cast<decltype(__VA_ARGS__)&&>(__VA_ARGS__)
+
 namespace kumi
 {
   //================================================================================================
@@ -157,27 +159,27 @@ namespace kumi
     // Tuple as functional object
     //==============================================================================================
     template<typename Function> constexpr decltype(auto) operator()(Function&& f) const &
-      noexcept(noexcept(kumi::apply(std::forward<Function>(f),*this)))
+      noexcept(noexcept(kumi::apply(OFW_FWD(f),*this)))
     {
-      return kumi::apply(std::forward<Function>(f),*this);
+      return kumi::apply(OFW_FWD(f),*this);
     }
 
     template<typename Function> constexpr decltype(auto) operator()(Function&& f) &
-      noexcept(noexcept(kumi::apply(std::forward<Function>(f),*this)))
+      noexcept(noexcept(kumi::apply(OFW_FWD(f),*this)))
     {
-      return kumi::apply(std::forward<Function>(f),*this);
+      return kumi::apply(OFW_FWD(f),*this);
     }
 
     template<typename Function> constexpr decltype(auto) operator()(Function&& f) const &&
-      noexcept(noexcept(kumi::apply(std::forward<Function>(f),std::move(*this))))
+      noexcept(noexcept(kumi::apply(OFW_FWD(f),static_cast<tuple const&&>(*this))))
     {
-      return kumi::apply(std::forward<Function>(f),std::move(*this));
+      return kumi::apply(OFW_FWD(f),static_cast<tuple const&&>(*this));
     }
 
     template<typename Function> constexpr decltype(auto) operator()(Function&& f) &&
-      noexcept(noexcept(kumi::apply(std::forward<Function>(f),std::move(*this))))
+      noexcept(noexcept(kumi::apply(OFW_FWD(f),static_cast<tuple&&>(*this))))
     {
-      return kumi::apply(std::forward<Function>(f),std::move(*this));
+      return kumi::apply(OFW_FWD(f),static_cast<tuple&&>(*this));
     }
 
     //==============================================================================================
@@ -261,7 +263,7 @@ namespace kumi
     {
       [&]<std::size_t... I>(std::index_sequence<I...>)
       {
-        ((detail::get_leaf<I>(impl) = detail::get_leaf<I>(std::move(other.impl))),...);
+        ((detail::get_leaf<I>(impl) = detail::get_leaf<I>(OFW_FWD(other).impl)),...);
       }(std::make_index_sequence<sizeof...(Ts)>());
 
       return *this;
@@ -315,13 +317,13 @@ namespace kumi
   template <typename... Ts>
   [[nodiscard]] constexpr tuple<Ts&&...> forward_as_tuple(Ts&&... ts)
   {
-    return {std::forward<Ts>(ts)...};
+    return {OFW_FWD(ts)...};
   }
 
   template <typename... Ts>
   [[nodiscard]] constexpr tuple<std::unwrap_ref_decay_t<Ts>...>  make_tuple(Ts&&... ts)
   {
-    return {std::forward<Ts>(ts)...};
+    return {OFW_FWD(ts)...};
   }
 
   template<typename... Ts>
@@ -379,7 +381,7 @@ namespace kumi
   {
     return  [&]<std::size_t... I>(std::index_sequence<I...>)
             {
-              return std::forward<Function>(f)(detail::get_leaf<I>(std::forward<Tuple>(t).impl)...);
+              return OFW_FWD(f)(detail::get_leaf<I>(OFW_FWD(t).impl)...);
             }(std::make_index_sequence<std::remove_cvref_t<Tuple>::size()>());
   }
 
@@ -490,7 +492,7 @@ namespace kumi
   template<product_type T1, product_type T2>
   [[nodiscard]] constexpr auto operator|(T1&& t1, T2&& t2)
   {
-    return kumi::cat(std::forward<T1>(t1), std::forward<T2>(t2));
+    return kumi::cat(OFW_FWD(t1), OFW_FWD(t2));
   }
 }
 


### PR DESCRIPTION
`std::forward<T>(t)` is redundant, and somewhat error prone