### PR TITLE
Revert implicit conversions - back to .cast and tuple_cast

### DIFF
--- a/include/kumi.hpp
+++ b/include/kumi.hpp
@@ -327,26 +327,16 @@ namespace kumi
     [[nodiscard]] static constexpr bool empty() noexcept { return sizeof...(Ts) == 0; }
 
     //==============================================================================================
-    // Conversions
+    // Conversion
     //==============================================================================================
     template<typename... Us>
-    requires( detail::piecewise_constructible<tuple<Us...>,tuple> )
-    explicit(!detail::piecewise_constructible<tuple<Us...>,tuple> )
-    constexpr operator tuple<Us...>() const
+    requires(     detail::piecewise_convertible<tuple,tuple<Us...>>
+              &&  (sizeof...(Us) == sizeof...(Ts))
+              &&  (!std::same_as<Ts,Us> && ...)
+            )
+    [[nodiscard]] inline constexpr auto cast() const
     {
-      return apply([](auto &&...elems) { return kumi::tuple{ static_cast<Us>(elems)...}; }, *this);
-    }
-
-    template<typename Type>
-    requires( detail::implicit_constructible<Type, Ts...> )
-    explicit(!detail::implicit_constructible<Type, Ts...> )
-    constexpr operator Type() const
-    {
-      return [&]<std::size_t... I>(std::index_sequence<I...>)
-      {
-        return Type{detail::get_leaf<I>(impl)...};
-      }
-      (std::make_index_sequence<sizeof...(Ts)>());
+      return apply([](auto &&...elems) { return tuple<Us...>{ static_cast<Us>(elems)...}; }, *this);
     }
 
     //==============================================================================================
@@ -446,6 +436,20 @@ namespace kumi
       [[nodiscard]] constexpr auto tuple<Ts...>::split(index_t<I0> const &) noexcept
   {
     return kumi::make_tuple(extract(index<0>, index<I0>), extract(index<I0>));
+  }
+
+  //================================================================================================
+  // Conversions to arbitrary types
+  //================================================================================================
+  template<typename Type, typename... Ts>
+  requires( !product_type<Type> && detail::implicit_constructible<Type, Ts...> )
+  [[nodiscard]] constexpr auto tuple_cast(tuple<Ts...> const& t)
+  {
+    return [&]<std::size_t... I>(std::index_sequence<I...>)
+    {
+      return Type{get<I>(t)...};
+    }
+    (std::make_index_sequence<sizeof...(Ts)>());
   }
 
   //================================================================================================

--- a/test/kumi/convert.cpp
+++ b/test/kumi/convert.cpp
@@ -15,10 +15,10 @@ TTS_CASE("Check tuple to tuple conversion")
 {
   kumi::tuple in{short{49},62.5f};
 
-  TTS_EQUAL ( (kumi::tuple<int ,double>(in)), (kumi::tuple{49 ,62.5}) );
-  TTS_EQUAL ( (kumi::tuple<char,int>(in))   , (kumi::tuple{'1',62})   );
+  TTS_EQUAL ( (in.cast<int ,double>() ) , (kumi::tuple{49 ,62.5}) );
+  TTS_EQUAL ( (in.cast<char,int>()    ) , (kumi::tuple{'1',62})   );
 
-  TTS_EQUAL ( kumi::tuple<std::string>(kumi::tuple{"some text"})
+  TTS_EQUAL ( kumi::tuple{"some text"}.cast<std::string>()
             , kumi::tuple{std::string("some text")}
             );
 }
@@ -27,8 +27,8 @@ TTS_CASE("Check tuple to tuple constexpr conversion")
 {
   constexpr kumi::tuple in{short{49},62.5f};
 
-  TTS_CONSTEXPR_EQUAL ( (kumi::tuple<int ,double>(in)), (kumi::tuple{49 ,62.5}) );
-  TTS_CONSTEXPR_EQUAL ( (kumi::tuple<char,int>(in))   , (kumi::tuple{'1',62})   );
+  TTS_CONSTEXPR_EQUAL ( (in.cast<int ,double>() ) , (kumi::tuple{49 ,62.5}) );
+  TTS_CONSTEXPR_EQUAL ( (in.cast<char,int>()    ) , (kumi::tuple{'1',62})   );
 }
 
 struct my_struct
@@ -42,12 +42,12 @@ TTS_CASE("Check tuple to constructible type conversion")
 {
   kumi::tuple in{std::size_t{9}, 13.37};
 
-  TTS_EQUAL ( my_struct(in), (my_struct{9,13.37}) );
+  TTS_EQUAL ( kumi::tuple_cast<my_struct>(in), (my_struct{9,13.37}) );
 }
 
 TTS_CASE("Check tuple to constructible type constexpr conversion")
 {
   constexpr kumi::tuple in{std::size_t{9}, 13.37};
 
-  TTS_CONSTEXPR_EQUAL ( my_struct(in), (my_struct{9,13.37}) );
+  TTS_CONSTEXPR_EQUAL ( kumi::tuple_cast<my_struct>(in), (my_struct{9,13.37}) );
 }


### PR DESCRIPTION
operator Type() broke zip and some other operations