### PR TITLE
Add flag-like keyword parameters

### DIFF
--- a/test/raberu/access.cpp
+++ b/test/raberu/access.cpp
@@ -14,10 +14,12 @@ TTS_CASE("Check settings(...) operator[t] behavior")
 {
   using namespace std::literals;
 
-  auto values = rbr::settings(coord_ = "Jane Doe"s, 42.69f);
+  auto values = rbr::settings(coord_ = "Jane Doe"s, 42.69f, is_modal_);
 
-  TTS_EQUAL(values[rbr::keyword<float>], 42.69f);
-  TTS_EQUAL(values[coord_], "Jane Doe"s);
+  TTS_EQUAL(values[rbr::keyword<float>] , 42.69f      );
+  TTS_EQUAL(values[coord_]              , "Jane Doe"s );
+  TTS_EQUAL(values[is_modal_]           , true        );
+  TTS_EQUAL(values[is_transparent_]     , false       );
 }
 
 TTS_CASE("Check settings(...) operator[t] life-time handling")
@@ -35,22 +37,27 @@ TTS_CASE("Check settings(...) operator[t] life-time handling")
 
 TTS_CASE("Check settings(...) operator[t] constexpr behavior")
 {
-  constexpr auto values = rbr::settings(coord_ = 75ULL, 42.69f);
+  constexpr auto values = rbr::settings(coord_ = 75ULL, is_transparent_, 42.69f);
 
-  TTS_CONSTEXPR_EQUAL(values[rbr::keyword<float>], 42.69f);
-  TTS_CONSTEXPR_EQUAL(values[coord_], 75ULL);
+  TTS_CONSTEXPR_EQUAL(values[rbr::keyword<float>] , 42.69f);
+  TTS_CONSTEXPR_EQUAL(values[coord_]              , 75ULL );
+  TTS_CONSTEXPR_EQUAL(values[is_transparent_]     , true  );
+  TTS_CONSTEXPR_EQUAL(values[is_modal_]           , false );
 }
 
 TTS_CASE("Check settings(...) operator[t | v] behavior")
 {
   using namespace std::literals;
+  using namespace rbr::literals;
 
-  auto values = rbr::settings(name_ = "Jane Doe"s);
+  auto values = rbr::settings(name_ = "Jane Doe"s, "default_init"_fl);
 
   TTS_EQUAL(values[rbr::keyword<char> | -99], -99);
   TTS_EQUAL(values[rbr::keyword<int> | -99], -99);
   TTS_EQUAL(values[rbr::keyword<float> | -99], -99);
   TTS_EQUAL(values[name_ | -99], "Jane Doe"s);
+  TTS_EQUAL(values["default_init"_fl | -99], true);
+  TTS_EQUAL(values["perform_copy"_fl | -99], -99);
 }
 
 TTS_CASE("Check settings(...) operator[t | v] life-time handling")
@@ -70,32 +77,43 @@ TTS_CASE("Check settings(...) operator[t | v] life-time handling")
 
 TTS_CASE("Check settings(...) operator[t | v] constexpr behavior")
 {
-  constexpr auto values = rbr::settings(coord_ = 75ULL);
+  using namespace rbr::literals;
+
+  constexpr auto values = rbr::settings("default_init"_fl, coord_ = 75ULL);
 
   TTS_CONSTEXPR_EQUAL(values[rbr::keyword<char> | -99], -99);
   TTS_CONSTEXPR_EQUAL(values[rbr::keyword<int> | -99], -99);
   TTS_CONSTEXPR_EQUAL(values[rbr::keyword<float> | -99], -99);
   TTS_CONSTEXPR_EQUAL(values[coord_ | -99], 75ULL);
+  TTS_CONSTEXPR_EQUAL(values["default_init"_fl | -99], true);
+  TTS_CONSTEXPR_EQUAL(values["perform_copy"_fl | -99], -99);
+
 }
 
 TTS_CASE("Check settings(...) operator[t | func()] behavior")
 {
-  auto values  = rbr::settings(value_ = 1337.42f);
+  auto values  = rbr::settings(value_ = 1337.42f, is_modal_);
   auto or_else = []<typename T>(rbr::keyword_type<T>) { return sizeof(T); };
 
-  TTS_EQUAL(values[rbr::keyword<char> | or_else], 1ULL);
-  TTS_EQUAL(values[rbr::keyword<double> | or_else], 8ULL);
-  TTS_EQUAL(values[value_ | or_else], 1337.42f);
-  TTS_EQUAL(values[coord_ | [](auto) { return 42ULL; }], 42ULL);
+  TTS_EQUAL(values[rbr::keyword<char>   | or_else], 1ULL    );
+  TTS_EQUAL(values[rbr::keyword<double> | or_else], 8ULL    );
+  TTS_EQUAL(values[value_               | or_else], 1337.42f);
+
+  TTS_EQUAL(values[coord_               | [](auto) { return 42ULL;  }], 42ULL   );
+  TTS_EQUAL(values[is_modal_            | [](auto) { return 42ULL;  }], true    );
+  TTS_EQUAL(values[is_transparent_      | [](auto) { return "oops"; }], "oops"  );
 }
 
 TTS_CASE("Check settings(...) operator[t | func()] constexpr behavior")
 {
-  constexpr auto values  = rbr::settings(value_ = 1337.42f);
+  constexpr auto values  = rbr::settings(is_modal_,value_ = 1337.42f);
   auto           or_else = []<typename T>(rbr::keyword_type<T>) { return 42.69; };
 
-  TTS_CONSTEXPR_EQUAL(values[rbr::keyword<char> | or_else], 42.69);
+  TTS_CONSTEXPR_EQUAL(values[rbr::keyword<char>   | or_else], 42.69);
   TTS_CONSTEXPR_EQUAL(values[rbr::keyword<double> | or_else], 42.69);
-  TTS_CONSTEXPR_EQUAL(values[value_ | or_else], 1337.42f);
-  TTS_CONSTEXPR_EQUAL(values[custom_ | or_else], 42.69);
+  TTS_CONSTEXPR_EQUAL(values[value_               | or_else], 1337.42f);
+  TTS_CONSTEXPR_EQUAL(values[custom_              | or_else], 42.69);
+
+  TTS_CONSTEXPR_EQUAL(values[is_modal_            | [](auto) { return 42ULL;  }], true  );
+  TTS_CONSTEXPR_EQUAL(values[is_transparent_      | [](auto) { return 13.37;  }], 13.37 );
 }

--- a/test/raberu/access.cpp
+++ b/test/raberu/access.cpp
@@ -108,12 +108,12 @@ TTS_CASE("Check settings(...) operator[t | func()] constexpr behavior")
 {
   constexpr auto values  = rbr::settings(is_modal_,value_ = 1337.42f);
   auto           or_else = []<typename T>(rbr::keyword_type<T>) { return 42.69; };
+  auto           flag_it = []<typename T>(rbr::flag_type<T>) { return 42.69; };
 
-  TTS_CONSTEXPR_EQUAL(values[rbr::keyword<char>   | or_else], 42.69);
-  TTS_CONSTEXPR_EQUAL(values[rbr::keyword<double> | or_else], 42.69);
+  TTS_CONSTEXPR_EQUAL(values[rbr::keyword<char>   | or_else], 42.69   );
+  TTS_CONSTEXPR_EQUAL(values[rbr::keyword<double> | or_else], 42.69   );
   TTS_CONSTEXPR_EQUAL(values[value_               | or_else], 1337.42f);
-  TTS_CONSTEXPR_EQUAL(values[custom_              | or_else], 42.69);
-
-  TTS_CONSTEXPR_EQUAL(values[is_modal_            | [](auto) { return 42ULL;  }], true  );
-  TTS_CONSTEXPR_EQUAL(values[is_transparent_      | [](auto) { return 13.37;  }], 13.37 );
+  TTS_CONSTEXPR_EQUAL(values[custom_              | or_else], 42.69   );
+  TTS_CONSTEXPR_EQUAL(values[is_modal_            | or_else], true    );
+  TTS_CONSTEXPR_EQUAL(values[is_transparent_      | flag_it], 42.69   );
 }

--- a/test/raberu/common.hpp
+++ b/test/raberu/common.hpp
@@ -40,3 +40,6 @@ inline constexpr auto value_  = ::rbr::keyword<float>;
 inline constexpr auto name_   = ::rbr::keyword<std::string>;
 inline constexpr auto factor_ = ::rbr::keyword<int>;
 inline constexpr auto ref_    = ::rbr::keyword<double>;
+
+inline constexpr auto is_transparent_ = ::rbr::flag<struct transparent>;
+inline constexpr auto is_modal_       = ::rbr::flag<struct modal>;

--- a/test/raberu/contains.cpp
+++ b/test/raberu/contains.cpp
@@ -13,15 +13,23 @@
 TTS_CASE("Check settings(...).contains behavior")
 {
   using namespace std::literals;
+  using namespace rbr::literals;
 
-  rbr::settings values(custom_ = foo {}, name_ = "john"s, value_ = 3.f);
+  rbr::settings values( custom_ = foo {}, "surname"_kw = "john"s, value_ = 3.f
+                      , "aligned"_fl, is_transparent_
+                      );
 
-  TTS_EXPECT(values.contains(custom_));
-  TTS_EXPECT(values.contains(name_));
-  TTS_EXPECT(values.contains(value_));
-  TTS_EXPECT_NOT(values.contains(rbr::keyword<char>));
-  TTS_EXPECT_NOT(values.contains(rbr::keyword<short>));
-  TTS_EXPECT_NOT(values.contains(rbr::keyword<void *>));
+  TTS_EXPECT(values.contains(custom_)         );
+  TTS_EXPECT(values.contains("surname"_kw)    );
+  TTS_EXPECT(values.contains(value_)          );
+  TTS_EXPECT(values.contains(is_transparent_) );
+  TTS_EXPECT(values.contains("aligned"_fl) );
+
+  TTS_EXPECT_NOT(values.contains(rbr::keyword<char>   ));
+  TTS_EXPECT_NOT(values.contains(rbr::keyword<short>  ));
+  TTS_EXPECT_NOT(values.contains(rbr::keyword<void *> ));
+  TTS_EXPECT_NOT(values.contains(is_modal_            ));
+  TTS_EXPECT_NOT(values.contains("compact"_fl         ));
 }
 
 TTS_CASE("Check settings(...).contains constexpr behavior")
@@ -29,13 +37,15 @@ TTS_CASE("Check settings(...).contains constexpr behavior")
   using namespace std::literals;
   using namespace rbr::literals;
 
-  constexpr rbr::settings values("custom"_kw = foo {}, name_ = 88, value_ = 3.f);
+  constexpr rbr::settings values("custom"_kw = foo {}, name_ = 88, value_ = 3.f, is_modal_);
 
-  TTS_CONSTEXPR_EXPECT(values.contains("custom"_kw));
-  TTS_CONSTEXPR_EXPECT(values.contains(name_));
-  TTS_CONSTEXPR_EXPECT(values.contains(value_));
+  TTS_CONSTEXPR_EXPECT(values.contains("custom"_kw) );
+  TTS_CONSTEXPR_EXPECT(values.contains(name_  )     );
+  TTS_CONSTEXPR_EXPECT(values.contains(value_ )     );
+  TTS_CONSTEXPR_EXPECT(values.contains(is_modal_)   );
 
-  TTS_CONSTEXPR_EXPECT_NOT(values.contains(rbr::keyword<char>));
-  TTS_CONSTEXPR_EXPECT_NOT(values.contains(rbr::keyword<short>));
-  TTS_CONSTEXPR_EXPECT_NOT(values.contains(rbr::keyword<void *>));
+  TTS_CONSTEXPR_EXPECT_NOT(values.contains(rbr::keyword<char> )   );
+  TTS_CONSTEXPR_EXPECT_NOT(values.contains(rbr::keyword<short>)   );
+  TTS_CONSTEXPR_EXPECT_NOT(values.contains(rbr::keyword<void *> ) );
+  TTS_CONSTEXPR_EXPECT_NOT(values.contains(is_transparent_  )     );
 }

--- a/test/raberu/interface.cpp
+++ b/test/raberu/interface.cpp
@@ -11,8 +11,7 @@
 #include <tts/tts.hpp>
 
 template<typename... Vs>
-constexpr auto
-typed_interface(Vs const &...vs) noexcept
+constexpr auto typed_interface(Vs const &...vs) noexcept
 {
   rbr::settings s(vs...);
   return s[rbr::keyword<int>] * s[rbr::keyword<double>];
@@ -20,6 +19,14 @@ typed_interface(Vs const &...vs) noexcept
 
 constexpr auto
 named_interface(rbr::keyword_parameter auto const &...vs) noexcept
+{
+  rbr::settings s(vs...);
+  return s[factor_] * s[ref_];
+}
+
+template<rbr::keyword_parameter... Vs>
+constexpr auto restricted_interface(Vs const &...vs) noexcept
+requires( rbr::match<Vs...>::with(factor_ | ref_ | is_modal_) )
 {
   rbr::settings s(vs...);
   return s[factor_] * s[ref_];
@@ -37,6 +44,14 @@ TTS_CASE("Check settings(...) as function interface with named parameters")
   TTS_EQUAL(named_interface(ref_ = 3.41, factor_ = 10), 34.1);
 }
 
+TTS_CASE("Check settings(...) as function interface with restricted named parameters")
+{
+  TTS_EQUAL(restricted_interface(factor_ = 10, ref_ = 3.41), 34.1);
+  TTS_EQUAL(restricted_interface(ref_ = 3.41, factor_ = 10), 34.1);
+  TTS_EQUAL(restricted_interface(factor_ = 10, ref_ = 3.41, is_modal_), 34.1);
+  TTS_EQUAL(restricted_interface(factor_ = 10, is_modal_, ref_ = 3.41), 34.1);
+}
+
 TTS_CASE("Check settings(...) as constexpr function interface with simple parameters")
 {
   TTS_CONSTEXPR_EQUAL(typed_interface(10, 3.41), 34.1);
@@ -47,4 +62,12 @@ TTS_CASE("Check settings(...) as constexpr function interface with named paramet
 {
   TTS_CONSTEXPR_EQUAL(named_interface(factor_ = 10, ref_ = 3.41), 34.1);
   TTS_CONSTEXPR_EQUAL(named_interface(ref_ = 3.41, factor_ = 10), 34.1);
+}
+
+TTS_CASE("Check settings(...) as constexpr function interface with restricted named parameters")
+{
+  TTS_CONSTEXPR_EQUAL(restricted_interface(factor_ = 10, ref_ = 3.41), 34.1);
+  TTS_CONSTEXPR_EQUAL(restricted_interface(ref_ = 3.41, factor_ = 10), 34.1);
+  TTS_CONSTEXPR_EQUAL(restricted_interface(factor_ = 10, ref_ = 3.41, is_modal_), 34.1);
+  TTS_CONSTEXPR_EQUAL(restricted_interface(factor_ = 10, is_modal_, ref_ = 3.41), 34.1);
 }


### PR DESCRIPTION
```c++
inline constexpr auto is_on = rbr::flag<struct is_on_>;

rbr::settings( is_on, "no_copy"_fl );
```

Flags are keywords with no value. Just being there is enough.
