### PR TITLE
Massive RABERU rewrite

### DIFF
--- a/include/raberu.hpp
+++ b/include/raberu.hpp
@@ -1,341 +1,368 @@
 //==================================================================================================
-/**
+/*
   RABERU - Fancy Parameters Library
   Copyright : OFW Contributors & Maintainers
   SPDX-License-Identifier: MIT
-**/
+*/
 //==================================================================================================
 #pragma once
+#include <ostream>
+#include <string_view>
 #include <type_traits>
 #include <utility>
 
 #define RBR_FWD(...) static_cast<decltype(__VA_ARGS__) &&>(__VA_ARGS__)
 
+namespace rbr::detail
+{
+  // Lightweight container of value in alternatives
+  template<typename T, typename V> struct type_or_ { V value; };
+
+  // Type -> String converter
+  template<typename T> struct type_name
+  {
+    static constexpr auto value() noexcept
+    {
+  #if defined(_MSC_VER )
+      std::string_view data(__FUNCSIG__);
+      auto i = data.find('<') + 1;
+      auto j = data.find(">::value");
+      return data.substr(i, j - i);
+  #else
+      std::string_view data(__PRETTY_FUNCTION__);
+      auto i = data.find('=') + 2;
+      auto j = data.find_last_of(']');
+      return data.substr(i, j - i);
+  #endif
+    }
+  };
+
+  // Helpers for working on list of keys as unique lists - needed by merge and some contains_*
+  template<typename... Ks> struct keys {};
+
+  template<typename K, typename Ks> struct contains;
+
+  template<typename... Ks, typename K>
+  struct  contains<K, keys<Ks...>> : std::bool_constant<(std::same_as<K,Ks> || ...)>
+  {};
+
+  template<typename K, typename Ks, bool>  struct append_if_impl;
+
+  template<typename... Ks, typename K> struct append_if_impl<K,keys<Ks...>,true>
+  {
+    using type = keys<Ks...>;
+  };
+
+  template<typename... Ks, typename K> struct append_if_impl<K,keys<Ks...>,false>
+  {
+    using type = keys<Ks...,K>;
+  };
+
+  template<typename K, typename Ks> struct append_if;
+
+  template<typename K, typename Ks>
+  struct append_if : append_if_impl<K,Ks, contains<K, Ks>::value>
+  {};
+
+  template<typename K1, typename K2> struct uniques;
+
+  template<typename K1s, typename K2, typename... K2s>
+  struct  uniques<K1s, keys<K2,K2s...>>
+        : uniques< typename append_if<K2,K1s>::type, keys<K2s...> >
+  {};
+
+  template<typename K1s> struct  uniques<K1s, keys<>> { using type = K1s; };
+
+  template<typename K1, typename K2> struct contain_all;
+
+  template<typename K1s, typename... K2s>
+  struct  contain_all<K1s, keys<K2s...>> : std::bool_constant<(contains<K2s,K1s>::value && ...)>
+  {};
+
+  template<typename K1s>  struct  contain_all<K1s   , keys<>>  : std::false_type {};
+  template<typename K2s>  struct  contain_all<keys<>, K2s   >  : std::false_type {};
+  template<>              struct  contain_all<keys<>,keys<>>   : std::true_type  {};
+
+  template<typename K1, typename K2>
+  struct is_equivalent : std::bool_constant<contain_all<K2,K1>::value && contain_all<K2,K1>::value>
+  {};
+}
+
 namespace rbr
 {
-  // Lightweight container of value
-  template<typename T, typename V> struct type_or_
-  {
-    V value;
-  };
-
-  template<typename... KWs> struct either_
-  {
-  };
-
-  // Basic checker for keyword constraints
-  struct any_type
-  {
-    template<typename T> struct check : std::true_type {};
-  };
-
-  // Turn any type into a RegularType info carrier
-  template<typename T, typename C = any_type> struct keyword_t
-  {
-    using type  = keyword_t<T,C>;
-
-    constexpr keyword_t() =default;
-    constexpr keyword_t(T const&) {}
-    constexpr keyword_t(T const&, C const&) {}
-
-    template<typename V>
-    requires( C::template check<V>::value )
-    constexpr auto operator=(V &&v) const noexcept;
-
-    template<typename V> constexpr auto operator|(V &&value) const noexcept
-    {
-      return type_or_<type, V> {RBR_FWD(value)};
-    }
-
-    template<typename U, typename K> constexpr auto operator|(keyword_t<U,K>) const noexcept
-    {
-      return either_<keyword_t<T,C>, keyword_t<U,K>> {};
-    }
-
-    template<typename... Kws>
-    friend constexpr auto operator|(either_<Kws...>, keyword_t) noexcept
-    {
-      return either_<Kws..., keyword_t<T,C>> {};
-    }
-
-    template<typename... Kws>
-    friend constexpr auto operator|(keyword_t, either_<Kws...>) noexcept
-    {
-      return either_<keyword_t<T,C>, Kws...> {};
-    }
-  };
-
-  // CTAD for keyword_t
-  template<typename ID> keyword_t(ID const&) -> keyword_t<ID>;
-  template<typename ID, typename C> keyword_t(ID const&, C const&) -> keyword_t<ID,C>;
-
-  // keyword_t generator
-  template<typename T, typename C = any_type>
-  inline constexpr const keyword_t<T,C> keyword = {};
-
-  // Flag-like keyword parameter
-  template<typename T> struct flag_type
-  {
-    static constexpr bool is_parameter_type     = true;
-    using key_type                              = flag_type<T>;
-    using type                                  = flag_type<T>;
-
-    constexpr flag_type() =default;
-    constexpr flag_type(T const&) {}
-
-    template<typename V> constexpr auto operator=(V&&) const noexcept
-    {
-      return *this;
-    }
-
-    template<typename V> constexpr auto operator|(V &&value) const noexcept
-    {
-      return type_or_<type, V> {RBR_FWD(value)};
-    }
-
-    template<typename U> constexpr auto operator|(flag_type<U>) const noexcept
-    {
-      return either_<flag_type<T>, flag_type<U>> {};
-    }
-
-    template<typename... Kws>
-    friend constexpr auto operator|(either_<Kws...>, flag_type) noexcept
-    {
-      return either_<Kws..., flag_type<T>> {};
-    }
-
-    template<typename... Kws>
-    friend constexpr auto operator|(flag_type, either_<Kws...>) noexcept
-    {
-      return either_<flag_type<T>, Kws...> {};
-    }
-
-    constexpr std::true_type operator()(flag_type<T> const&) noexcept { return {}; }
-  };
-
-  // CTAD for flag_type
-  template<typename ID> flag_type(ID const&) -> flag_type<ID>;
-
-  // flag_type generator
-  template<typename T> inline constexpr const flag_type<T> flag = {};
-
-  // ID/Keyword/Flag-type user defined literals
+  // ID user defined literals
   namespace literals
   {
     template<char... Char> struct id_
     {
+      std::ostream& show(std::ostream& os) const { char name[] = { Char... }; return os << name; }
     };
 
-    template<typename T, T... Chars> constexpr auto operator""_id() noexcept
-    {
-      return id_<Chars...>{};
-    }
-
-    template<typename T, T... Chars> constexpr auto operator""_kw() noexcept
-    {
-      return rbr::keyword<id_<Chars...>>;
-    }
-
-    template<typename T, T... Chars> constexpr auto operator""_fl() noexcept
-    {
-      return rbr::flag<id_<Chars...>>;
-    }
+    template<typename T, T... Cs> constexpr auto operator""_id() noexcept { return id_<Cs...>{}; }
   }
 
-  namespace detail
+  namespace concepts
   {
-    // Turn a Type+Value pair into a Callable
-    template<typename Key, typename Callable> struct linked_value : Callable
+    // Keyword concept
+    template<typename K> concept keyword = requires( K k )
     {
-      static constexpr bool is_parameter_type = true;
-      using key_type                          = Key;
-
-      constexpr linked_value(Key, Callable f) noexcept : Callable(f) {}
-      using Callable::operator();
+      typename K::tag_type;
+      { K::template accept<int>() } -> std::same_as<bool>;
     };
-  }
 
-  // keyword parameter concept
-  template<typename T> concept keyword_parameter = std::remove_cvref_t<T>::is_parameter_type;
-
-  // Type notifying that we can't find a given key
-  struct unknown_key
-  {
-    template<typename... T> unknown_key(T &&...) {}
-  };
-
-  namespace detail
-  {
-    // Build the type->value lambda capture
-    template<typename Key, typename T> constexpr auto link(T &&v) noexcept
+    // Option concept
+    template<typename O> concept option = requires( O const& o )
     {
-      if constexpr( keyword_parameter<std::decay_t<T>> )
-      {
-        return RBR_FWD(v);
-      }
-      else if constexpr( std::is_lvalue_reference_v<T> )
-      {
-        return linked_value(
-            Key {}, [&v](Key const &) constexpr->decltype(auto) { return v; });
-      }
-      else
-      {
-        return linked_value(
-            Key {}, [w = std::move(v)](Key const &) constexpr->T const & { return w; });
-      }
-    }
-
-    // Check if the key we used is correct
-    template<typename T> inline constexpr bool is_unknown_v              = false;
-    template<> inline constexpr bool           is_unknown_v<unknown_key> = true;
-
-    // Aggregate lambdas and give them a operator(Key)-like interface
-    template<typename... Ts> struct aggregator : Ts...
-    {
-      constexpr aggregator(Ts &&...t) noexcept : Ts(RBR_FWD(t))... {}
-      using Ts::operator()...;
-
-      template<typename K, typename C>
-      constexpr auto operator()(keyword_t<K,C> const &) const noexcept
-      {
-        // If not found before, return the unknown_key value
-        return unknown_key {};
-      }
-
-      template<typename K> constexpr auto operator()(flag_type<K> const &) const noexcept
-      {
-        // If not found before, return the unknown_key value
-        return unknown_key {};
-      }
+      { o(typename O::keyword_type{}) } -> std::same_as<typename O::value_type>;
     };
+
+    // Type checker concept
+    template<typename C> concept type_checker = requires( C const& )
+    {
+      typename C::template apply<int>::type;
+    };
+
+    // keyword parameter exact match
+    template<typename Option, auto Keyword>
+    concept exactly = std::same_as< typename Option::keyword_type
+                                  , std::remove_cvref_t<decltype(Keyword)>
+                                  >;
   }
 
-  // Build a key-value from an option object
-  template<typename T, typename C>
-  template<typename V>
-  requires( C::template check<V>::value )
-  constexpr auto keyword_t<T,C>::operator=(V &&v) const noexcept
+  // Option implementation
+  template<concepts::keyword Keyword, typename Value> struct option
   {
-    return detail::link<keyword_t<T,C>>(RBR_FWD(v));
+    using value_type    = Value;
+    using keyword_type  = Keyword;
+
+    constexpr value_type operator()(keyword_type const&) const noexcept { return contents; }
+    Value contents;
+  };
+
+  // checked_keyword implementation
+  template<typename Tag, typename Traits> struct checked_keyword
+  {
+    using tag_type  = Tag;
+
+    constexpr checked_keyword() {}
+    constexpr checked_keyword(Tag, Traits) {}
+
+    template<typename T> static constexpr bool accept()
+    {
+      return Traits::template apply<std::remove_cvref_t<T>>::value;
+    }
+
+    template<typename Type>
+    constexpr auto operator=(Type&& v) const noexcept requires( accept<Type>() )
+    {
+      return option<checked_keyword,std::remove_cvref_t<Type>>{RBR_FWD(v)};
+    }
+
+    template<typename Type>
+    constexpr auto operator|(Type&& v) const noexcept requires( accept<Type>() )
+    {
+      return detail::type_or_<checked_keyword,std::remove_cvref_t<Type>>{RBR_FWD(v)};
+    }
+
+    template<typename Type>
+    constexpr auto operator|(Type&& v) const noexcept requires std::invocable<Type>
+    {
+      return detail::type_or_<checked_keyword,Type>{RBR_FWD(v)};
+    }
+  };
+
+  // Keyword accepting a precise type as input
+  template<typename Tag, typename Value> struct typed_keyword
+  {
+    using tag_type  = Tag;
+
+    template<typename T> static constexpr bool accept() { return std::is_same_v<T,Value>; }
+
+    template<typename Type>
+    constexpr auto operator=(Type&& v) const noexcept requires( accept<Type>() )
+    {
+      return option<typed_keyword,std::remove_cvref_t<Type>>{RBR_FWD(v)};
+    }
+
+    template<typename Type>
+    constexpr auto operator|(Type&& v) const noexcept requires( accept<Type>() )
+    {
+      return detail::type_or_<typed_keyword,std::remove_cvref_t<Type>>{RBR_FWD(v)};
+    }
+
+    template<typename Type>
+    constexpr auto operator|(Type&& v) const noexcept requires std::invocable<Type>
+    {
+      return detail::type_or_<typed_keyword,Type>{RBR_FWD(v)};
+    }
+  };
+
+  // Keyword accepting any type as input
+  template<typename Tag> struct any_keyword
+  {
+    using tag_type  = Tag;
+
+    template<typename T> static constexpr bool accept() { return !std::invocable<T>; }
+
+    template<typename Type>
+    constexpr auto operator=(Type&& v) const noexcept requires( accept<Type>() )
+    {
+      return option<any_keyword,std::remove_cvref_t<Type>>{RBR_FWD(v)};
+    }
+
+    template<typename Type>
+    constexpr auto operator|(Type&& v) const noexcept requires( accept<Type>() )
+    {
+      return detail::type_or_<any_keyword,std::remove_cvref_t<Type>>{RBR_FWD(v)};
+    }
+
+    template<typename Type>
+    constexpr auto operator|(Type&& v) const noexcept requires std::invocable<Type>
+    {
+      return detail::type_or_<any_keyword,Type>{RBR_FWD(v)};
+    }
+  };
+
+  // Flags are keyword/options which value is given by its sole presence
+  template<typename Keyword> struct flag_keyword
+  {
+    constexpr flag_keyword() {}
+    constexpr flag_keyword(Keyword const&) {}
+
+    template<typename T> static constexpr bool accept()
+    {
+      return std::is_same_v<std::true_type, T>;
+    }
+
+    using tag_type      = Keyword;
+    using keyword_type  = flag_keyword;
+    using value_type    = std::true_type;
+
+    template<typename Type>
+    constexpr auto operator=(Type&&) const noexcept
+    {
+      return *this;
+    }
+
+    template<typename Type>
+    constexpr auto operator|(Type&& v) const noexcept
+    {
+      return detail::type_or_<flag_keyword,std::remove_cvref_t<Type>>{RBR_FWD(v)};
+    }
+
+    template<typename Type>
+    constexpr auto operator|(Type&& v) const noexcept requires std::invocable<Type>
+    {
+      return detail::type_or_<flag_keyword,Type>{RBR_FWD(v)};
+    }
+
+    constexpr std::true_type operator()(keyword_type const&) const noexcept { return {}; }
+  };
+
+  // Keyword builder
+  template<typename Tag> constexpr flag_keyword<Tag>  flag(Tag) noexcept { return {}; }
+  template<typename Tag> constexpr any_keyword<Tag>   keyword(Tag) noexcept { return {}; }
+
+  template<typename Type, typename Tag>
+  constexpr typed_keyword<Tag, Type> keyword(Tag) noexcept { return {}; }
+
+  template<concepts::type_checker Checker, typename Tag>
+  constexpr checked_keyword<Tag,Checker> keyword(Tag) noexcept { return {}; }
+
+  // Keyword/Flag-type user defined literals
+  namespace literals
+  {
+    template<typename T, T... Chars>
+    constexpr auto operator""_kw() noexcept { return any_keyword<id_<Chars...>>{}; }
+
+    template<typename T, T... Chars>
+    constexpr auto operator""_fl() noexcept { return flag_keyword<id_<Chars...>>{}; }
   }
 
-  // Extract tag from an Option
-  template<typename O> struct tag
+  // Tag for when something is not found in an aggregator
+  struct unknown_key {};
+
+  // Option calls aggregator
+  template<concepts::option... Ts> struct aggregator : Ts...
   {
-    using type = keyword_t<O>;
-  };
+    constexpr aggregator(Ts const&...t) noexcept : Ts(t)... {}
+    using Ts::operator()...;
 
-  template<typename O, typename C> struct tag<keyword_t<O,C>>
-  {
-    using type = keyword_t<O,C>;
-  };
-
-  template<typename O> struct tag<flag_type<O>>
-  {
-    using type = flag_type<O>;
-  };
-
-  template<typename K, typename C> struct tag<detail::linked_value<K, C>>
-  {
-    using type = K;
-  };
-
-  template<typename O> using tag_t = typename tag<O>::type;
-
-  template<typename...> struct keys
-  {
-  };
-  template<typename...> struct links
-  {
-  };
-
-  // settings is an unordered set of values accessible via their types
-  template<typename Keys, typename Links> struct settings;
-
-  template<typename... Ks, typename... Ts> struct settings<keys<Ks...>, links<Ts...>>
-  {
-    using keys_type  = keys<Ks...>;
-    using links_type = links<Ks...>;
-    using parent     = detail::aggregator<Ts...>;
-
-    template<typename... Vs>
-    constexpr settings(Vs &&...v) : content_(detail::link<Ks>(RBR_FWD(v))...)
+    template<concepts::keyword K> constexpr auto operator()(K const &) const noexcept
     {
-    }
-
-    static constexpr std::ptrdiff_t size() noexcept { return sizeof...(Ts); }
-
-    // Named options interface
-    template<typename T, typename C>
-    static constexpr auto contains(keyword_t<T,C> const &) noexcept
-    {
-      using found = decltype(std::declval<parent>()(tag_t<T> {}));
-      return std::bool_constant<!detail::is_unknown_v<found>>{};
-    }
-
-    template<typename T> static constexpr auto contains(flag_type<T> const &) noexcept
-    {
-      using found = decltype(std::declval<parent>()(flag_type<T> {}));
-      return std::bool_constant<!detail::is_unknown_v<found>>{};
-    }
-
-    template<typename T, typename C>
-    constexpr decltype(auto) operator[](keyword_t<T,C> const &tgt) const noexcept
-    {
-      return content_(tgt);
-    }
-
-    template<typename T>
-    constexpr auto operator[](flag_type<T> const &tgt) const noexcept
-    {
-      return contains(tgt);
-    }
-
-    template<typename T, typename V>
-    constexpr decltype(auto) operator[](type_or_<T, V> const &tgt) const
-    {
-            if constexpr( contains(T{}) )             return (*this)[T{}];
-      else  if constexpr( std::is_invocable_v<V, T> ) return tgt.value(T{});
-      else                                            return tgt.value;
-    }
-
-    // Pattern matcher
-    template<typename... KW> static inline constexpr bool validate(either_<KW...> const &) noexcept
-    {
-      auto is_ok = []<typename K>(K) { return (std::same_as<K, KW> || ... || false); };
-      return (is_ok(Ks {}) && ... && true);
-    }
-
-    template<typename K, typename C>
-    static inline constexpr bool validate(keyword_t<K,C> const &) noexcept
-    {
-      return (std::same_as<Ks, keyword_t<K>> && ... && true);
-    }
-
-    template<typename K> static inline constexpr bool validate(flag_type<K> const &) noexcept
-    {
-      return (std::same_as<Ks, flag_type<K>> && ... && true);
-    }
-
-    parent content_;
-  };
-
-  template<typename... Vs>
-  settings(Vs &&...v)
-      -> settings<keys<tag_t<std::decay_t<Vs>>...>,
-                  links<decltype(detail::link<tag_t<std::decay_t<Vs>>>(RBR_FWD(v)))...>>;
-
-  // Pattern matcher entry point
-  template<typename... Args> struct match
-  {
-    template<typename Pattern> static inline constexpr bool with(Pattern p)
-    {
-      return decltype(rbr::settings {std::declval<Args>()...})::validate(p);
+      return unknown_key {};
     }
   };
 
-  // keyword parameter exact match concept
-  template<typename Param, auto Keyword> concept exactly = rbr::match<Param>::with(Keyword);
+  // Settings is a group of options
+  template<concepts::option... Opts> struct settings
+  {
+    using base = aggregator<Opts...>;
+    constexpr settings(Opts const&... opts) : content_(opts...) {}
+
+    static constexpr std::ptrdiff_t size() noexcept { return sizeof...(Opts); }
+
+    template<concepts::keyword Key>
+    static constexpr auto contains(Key const &) noexcept
+    {
+      using found = decltype((std::declval<base>())(Key{}));
+      return std::bool_constant<!std::same_as<found, unknown_key> >{};
+    }
+
+    template<concepts::keyword... Keys>
+    static constexpr auto contains_any(Keys... ks) noexcept { return (contains(ks) || ...); }
+
+    template<concepts::keyword... Keys>
+    static constexpr auto contains_only(Keys const&...) noexcept
+    {
+      using current_keys    = detail::keys<typename Opts::keyword_type...>;
+      using acceptable_keys = detail::keys<Keys...>;
+      using unique_set      = typename detail::uniques<current_keys,acceptable_keys>::type;
+      return  detail::is_equivalent<unique_set, acceptable_keys>::value;
+    }
+
+    template<concepts::keyword... Keys>
+    static constexpr auto contains_none(Keys... ks) noexcept { return !contains_any(ks...); }
+
+    template<concepts::keyword Key> constexpr auto operator[](Key const& k) const noexcept
+    {
+      return content_(k);
+    }
+
+    template<typename Keyword>
+    constexpr auto operator[](flag_keyword<Keyword> const&) const noexcept
+    {
+      return contains(flag_keyword<Keyword>{});
+    }
+
+    template<concepts::keyword Key, typename Value>
+    constexpr auto operator[](detail::type_or_<Key, Value> const & tgt) const
+    {
+            if constexpr( contains(Key{}) ) return (*this)[Key{}];
+      else  if constexpr( std::is_invocable_v<Value> ) return tgt.value();
+      else                                             return tgt.value;
+    }
+
+    friend std::ostream& operator<<(std::ostream& os, settings const& s)
+    {
+      auto show = [&]<typename T>(T t) -> std::ostream&
+      {
+        if constexpr( requires(T t) { t.show(os); } ) return t.show(os);
+        else                                          return os << detail::type_name<T>::value();
+      };
+
+      ( ( show(typename Opts::keyword_type::tag_type{}) << " : " << s[typename Opts::keyword_type{}]
+          << " (" << detail::type_name<typename Opts::value_type>::value() << ")\n"
+        ),...);
+
+      return os;
+    }
+
+    base content_;
+  };
+
+  template<concepts::option... Opts>
+  settings(Opts&&... opts) -> settings<std::remove_cvref_t<Opts>...>;
 
   // Traits to fetch type of an option from the type of a Settings
   template<typename Settings, auto Keyword, typename Default = unknown_key>
@@ -355,60 +382,24 @@ namespace rbr
   using get_type_t = typename get_type<Settings,Keyword,Default>::type;
 
   // Merge settings
-  namespace detail
+  template<concepts::option... K1s, concepts::option... K2s>
+  constexpr auto merge(settings<K1s...> const& opts, settings<K2s...> const& defs) noexcept
   {
-    template<typename K, typename Ks>        struct contains;
+    auto selector = []<typename K, typename Opts>(K const&, Opts const& o, auto const& d)
+                    {
+                      constexpr K key;
+                      if constexpr( Opts::contains(key) ) return (key = o[key]);
+                      else                                return (key = d[key]);
+                    };
 
-    template<typename... Ks, typename K>
-    struct  contains<K, keys<Ks...>> : std::bool_constant<(std::same_as<K,Ks> || ...)>
-    {};
-
-    template<typename K, typename Ks, bool>  struct append_if_impl;
-
-    template<typename... Ks, typename K> struct append_if_impl<K,keys<Ks...>,true>
+    auto select = [&]<typename... Ks>(detail::keys<Ks...> const&, auto const& os, auto const& ds)
     {
-      using type = keys<Ks...>;
+      return settings(selector(Ks{},os,ds)...);
     };
 
-    template<typename... Ks, typename K> struct append_if_impl<K,keys<Ks...>,false>
-    {
-      using type = keys<Ks...,K>;
-    };
-
-    template<typename K, typename Ks>        struct append_if;
-
-    template<typename K, typename Ks>
-    struct append_if : append_if_impl<K,Ks, contains<K, Ks>::value>
-    {};
-
-    template<typename K1, typename K2> struct uniques;
-
-    template<typename K1s, typename K2, typename... K2s>
-    struct  uniques<K1s, keys<K2,K2s...>>
-          : uniques< typename append_if<K2,K1s>::type, keys<K2s...> >
-    {};
-
-    template<typename K1s> struct  uniques<K1s, keys<>> { using type = K1s; };
-  }
-
-  template<typename... K1s, typename L1, typename... K2s, typename L2>
-  auto merge( settings<keys<K1s...>, L1> const& opts
-            , settings<keys<K2s...>, L2> const& defs
-            ) noexcept
-  {
-    auto select = []<typename... Ks>(keys<Ks...>, auto const& os, auto const& ds)
-    {
-      auto selector = []<typename K, typename Opts>(keys<K>, Opts const& o, auto const& d)
-                      {
-                        constexpr K key;
-                        if constexpr( Opts::contains(key) ) return (key = o[key]);
-                        else                                return (key = d[key]);
-                      };
-
-      return settings(selector(keys<Ks>{},os,ds)...);
-    };
-
-    return select(typename detail::uniques<keys<K1s...>,keys<K2s...>>::type{},opts,defs);
+    return select(typename detail::uniques<detail::keys<typename K1s::keyword_type...>
+                                          ,detail::keys<typename K2s::keyword_type...>
+                                          >::type{},opts,defs);
   }
 }
 

--- a/test/raberu/CMakeLists.txt
+++ b/test/raberu/CMakeLists.txt
@@ -4,11 +4,22 @@
 ##  SPDX-License-Identifier: MIT
 ##==================================================================================================
 
+add_custom_target(raberu.exe)
+
 generate_test("raberu" "access.cpp")
 generate_test("raberu" "concepts.cpp")
-generate_test("raberu" "contains.cpp")
 generate_test("raberu" "constraints.cpp")
+generate_test("raberu" "contains.cpp")
 generate_test("raberu" "get_type.cpp")
 generate_test("raberu" "interface.cpp")
 generate_test("raberu" "merge.cpp")
 generate_test("raberu" "size.cpp")
+
+add_dependencies(raberu.exe raberu.access.exe)
+add_dependencies(raberu.exe raberu.concepts.exe)
+add_dependencies(raberu.exe raberu.constraints.exe)
+add_dependencies(raberu.exe raberu.contains.exe)
+add_dependencies(raberu.exe raberu.get_type.exe)
+add_dependencies(raberu.exe raberu.interface.exe)
+add_dependencies(raberu.exe raberu.merge.exe)
+add_dependencies(raberu.exe raberu.size.exe)

--- a/test/raberu/common.hpp
+++ b/test/raberu/common.hpp
@@ -6,40 +6,59 @@
 **/
 //==================================================================================================
 #pragma once
-#include <array>
 #include <raberu.hpp>
+#include <array>
 #include <string>
+
+using namespace rbr::literals;
 
 template<bool B> using bool_ = std::bool_constant<B>;
 
+using point = std::array<int, 3>;
+
 struct foo
 {
-  int value = 42;
+  int    value = 42;
+  friend std::ostream& operator<<(std::ostream& os, foo f) { return os << f.value; }
 };
+
 struct bar
 {
   double value = 4.2;
+  friend std::ostream& operator<<(std::ostream& os, bar b) { return os << b.value; }
 };
 
-using point = std::array<int, 3>;
-
-inline constexpr auto custom_ = ::rbr::keyword<struct custom_tag>;
-inline constexpr auto coord_  = ::rbr::keyword<struct coord_tag>;
-
-namespace rbr
+struct small_type
 {
-  template<> struct tag<foo> : tag<struct custom_tag>
-  {
-  };
-  template<> struct tag<bar> : tag<struct custom_tag>
-  {
-  };
-}
+  template<typename T> struct apply : std::bool_constant<(sizeof(T) < 4)> {};
+};
 
-inline constexpr auto value_  = ::rbr::keyword<float>;
-inline constexpr auto name_   = ::rbr::keyword<std::string>;
-inline constexpr auto factor_ = ::rbr::keyword<int>;
-inline constexpr auto ref_    = ::rbr::keyword<double>;
+inline constexpr auto custom_ = ::rbr::keyword("custom"_id);
+inline constexpr auto coord_  = "coord"_kw;
 
-inline constexpr auto is_transparent_ = ::rbr::flag<struct transparent>;
-inline constexpr auto is_modal_       = ::rbr::flag<struct modal>;
+inline constexpr auto value_  = ::rbr::keyword<float>("value"_id);
+inline constexpr auto name_   = ::rbr::keyword<std::string>("name"_id);
+
+inline constexpr auto factor_ = ::rbr::keyword<small_type>("factor"_id);
+
+inline constexpr auto is_transparent_ = ::rbr::flag("is_transparent"_id);
+inline constexpr auto is_modal_       = "is_modal"_fl;
+
+struct is_integral_constant
+{
+  template<typename T>      struct apply                               : std::false_type {};
+  template<typename T, T N> struct apply<std::integral_constant<T,N>>  : std::true_type {};
+};
+
+struct unrolling : rbr::checked_keyword<unrolling, is_integral_constant>
+{
+  template<int N>
+  constexpr auto operator=(std::integral_constant<int,N> const&) const noexcept
+  {
+    return rbr::option<unrolling,std::integral_constant<int,N>>{};
+  }
+
+  std::ostream& name(std::ostream& os) const { return os << "Unroll Factor: "; }
+};
+
+template<int N> inline constexpr auto unroll = (unrolling{} = std::integral_constant<int,N>{});

--- a/test/raberu/concepts.cpp
+++ b/test/raberu/concepts.cpp
@@ -10,16 +10,46 @@
 #include <raberu.hpp>
 #include <tts/tts.hpp>
 
-TTS_CASE("Check rbr::keyword_parameters concept")
+TTS_CASE("Check rbr::concepts::keyword concept")
 {
   using namespace rbr::literals;
 
-  auto param = (coord_ = 9);
+  // Direct type
+  TTS_EXPECT(   rbr::concepts::keyword< rbr::flag_keyword   <struct key>            > );
+  TTS_EXPECT(   rbr::concepts::keyword< rbr::any_keyword    <struct key>            > );
+  TTS_EXPECT( ( rbr::concepts::keyword< rbr::typed_keyword  <struct key, double>    >));
+  TTS_EXPECT( ( rbr::concepts::keyword< rbr::checked_keyword<struct key, small_type>>));
 
-  TTS_EXPECT( rbr::keyword_parameter<decltype(param             )> );
-  TTS_EXPECT( rbr::keyword_parameter<decltype("local"_kw = 6.34f)> );
-  TTS_EXPECT_NOT( rbr::keyword_parameter<decltype("local"_kw)> );
-  TTS_EXPECT_NOT( rbr::keyword_parameter<float**> );
+  // Predefined keyword object
+  TTS_EXPECT(   rbr::concepts::keyword< decltype(custom_) > );
+  TTS_EXPECT(   rbr::concepts::keyword< decltype(coord_ ) > );
+
+  // Type from polymorphic constructor
+  TTS_EXPECT(   rbr::concepts::keyword< decltype(rbr::keyword("any"_id)) > );
+  TTS_EXPECT(   rbr::concepts::keyword< decltype(rbr::keyword<small_type>("small"_id)) > );
+  TTS_EXPECT(   rbr::concepts::keyword< decltype(rbr::keyword<float>("real_value"_id)) > );
+  TTS_EXPECT(   rbr::concepts::keyword< decltype(rbr::flag("modal"_id)) > );
+
+  // Type from literals
+  TTS_EXPECT(   rbr::concepts::keyword< decltype("any"_kw) > );
+  TTS_EXPECT(   rbr::concepts::keyword< decltype("modal"_fl) > );
+
+  // Obviously wrong type
+  TTS_EXPECT_NOT( rbr::concepts::keyword<float**> );
+};
+
+struct my_little_keyword : rbr::checked_keyword<struct key, small_type>
+{
+  using parent = rbr::checked_keyword<struct key, small_type>;
+  using parent::operator=;
+};
+
+TTS_CASE("Check rbr::concepts::option concept")
+{
+  TTS_EXPECT( (rbr::concepts::option<rbr::option<rbr::any_keyword<struct key> , int>>) );
+  TTS_EXPECT( (rbr::concepts::option<rbr::option<my_little_keyword            , int>>) );
+  TTS_EXPECT( (rbr::concepts::option<rbr::flag_keyword<struct key>                  >) );
+  TTS_EXPECT_NOT(rbr::concepts::option<float**> );
 };
 
 TTS_CASE("Check rbr::exactly concept")
@@ -28,7 +58,7 @@ TTS_CASE("Check rbr::exactly concept")
 
   auto param = (coord_ = 9);
 
-  TTS_EXPECT( (rbr::exactly<decltype(param)              , coord_    >) );
-  TTS_EXPECT( (rbr::exactly<decltype("local"_kw = 6.34f) , "local"_kw>) );
-  TTS_EXPECT_NOT( (rbr::exactly<decltype("local"_kw = 77), coord_    >) );
+  TTS_EXPECT( (rbr::concepts::exactly<decltype(param)              , coord_    >) );
+  TTS_EXPECT( (rbr::concepts::exactly<decltype("local"_kw = 6.34f) , "local"_kw>) );
+  TTS_EXPECT_NOT( (rbr::concepts::exactly<decltype("local"_kw = 77), coord_    >) );
 };

--- a/test/raberu/constraints.cpp
+++ b/test/raberu/constraints.cpp
@@ -12,23 +12,22 @@
 
 struct real_type
 {
-  template<typename T> struct check : std::is_floating_point<T> {};
+  template<typename T> struct apply : std::is_floating_point<T> {};
 };
 
 struct small_type
 {
-  template<typename T> struct check : std::bool_constant<(sizeof(T) < 4)> {};
+  template<typename T> struct apply : std::bool_constant<(sizeof(T) < 4)> {};
 };
 
 using namespace rbr::literals;
 
-inline constexpr auto angle              = rbr::keyword<struct angle   , real_type >;
-inline constexpr rbr::keyword_t pattern  = { "pattern"_id , small_type{} };
+inline constexpr rbr::checked_keyword<struct angle_, real_type >  angle = {};
+inline constexpr auto pattern = rbr::keyword<small_type>( "pattern"_id);
 
 TTS_CASE("Check constrainted keyword::operator= behavior")
 {
   rbr::settings s( angle = 3., pattern = 'z');
-
   TTS_EQUAL( s[angle]   , 3.  );
   TTS_EQUAL( s[pattern] , 'z' );
 };

--- a/test/raberu/contains.cpp
+++ b/test/raberu/contains.cpp
@@ -15,21 +15,18 @@ TTS_CASE("Check settings(...).contains behavior")
   using namespace std::literals;
   using namespace rbr::literals;
 
-  rbr::settings values( custom_ = foo {}, "surname"_kw = "john"s, value_ = 3.f
-                      , "aligned"_fl, is_transparent_
+  rbr::settings values( custom_ = foo {}, "surname"_kw = "john"s
+                      , value_ = 3.f, "aligned"_fl,is_transparent_
                       );
 
   TTS_EXPECT(values.contains(custom_)         );
   TTS_EXPECT(values.contains("surname"_kw)    );
   TTS_EXPECT(values.contains(value_)          );
   TTS_EXPECT(values.contains(is_transparent_) );
-  TTS_EXPECT(values.contains("aligned"_fl) );
+  TTS_EXPECT(values.contains("aligned"_fl)    );
 
-  TTS_EXPECT_NOT(values.contains(rbr::keyword<char>   ));
-  TTS_EXPECT_NOT(values.contains(rbr::keyword<short>  ));
-  TTS_EXPECT_NOT(values.contains(rbr::keyword<void *> ));
-  TTS_EXPECT_NOT(values.contains(is_modal_            ));
-  TTS_EXPECT_NOT(values.contains("compact"_fl         ));
+  TTS_EXPECT_NOT(values.contains(is_modal_    ));
+  TTS_EXPECT_NOT(values.contains("compact"_fl ));
 };
 
 TTS_CASE("Check settings(...).contains constexpr behavior")
@@ -37,15 +34,94 @@ TTS_CASE("Check settings(...).contains constexpr behavior")
   using namespace std::literals;
   using namespace rbr::literals;
 
-  constexpr rbr::settings values("custom"_kw = foo {}, name_ = 88, value_ = 3.f, is_modal_);
+  constexpr rbr::settings values("custom"_kw = foo {}, value_ = 3.f, is_modal_);
 
   TTS_CONSTEXPR_EXPECT(values.contains("custom"_kw) );
-  TTS_CONSTEXPR_EXPECT(values.contains(name_  )     );
   TTS_CONSTEXPR_EXPECT(values.contains(value_ )     );
   TTS_CONSTEXPR_EXPECT(values.contains(is_modal_)   );
 
-  TTS_CONSTEXPR_EXPECT_NOT(values.contains(rbr::keyword<char> )   );
-  TTS_CONSTEXPR_EXPECT_NOT(values.contains(rbr::keyword<short>)   );
-  TTS_CONSTEXPR_EXPECT_NOT(values.contains(rbr::keyword<void *> ) );
-  TTS_CONSTEXPR_EXPECT_NOT(values.contains(is_transparent_  )     );
+  TTS_CONSTEXPR_EXPECT_NOT(values.contains(is_transparent_) );
+  TTS_CONSTEXPR_EXPECT_NOT(values.contains("compact"_fl   ) );
+};
+
+TTS_CASE("Check settings(...).contains_any behavior")
+{
+  using namespace std::literals;
+  using namespace rbr::literals;
+
+  rbr::settings values( custom_ = foo {}, "surname"_kw = "john"s
+                      , value_ = 3.f, "aligned"_fl,is_transparent_
+                      );
+
+  TTS_EXPECT    (values.contains_any(custom_, is_transparent_, "compact"_fl) );
+  TTS_EXPECT_NOT(values.contains_any(is_modal_, "compact"_fl) );
+};
+
+TTS_CASE("Check settings(...).contains_any constexpr behavior")
+{
+  using namespace std::literals;
+  using namespace rbr::literals;
+
+  constexpr rbr::settings values("custom"_kw = foo {}, value_ = 3.f, is_modal_);
+
+  TTS_CONSTEXPR_EXPECT    (values.contains_any(value_, is_modal_, "custom"_kw) );
+  TTS_CONSTEXPR_EXPECT_NOT(values.contains_any(is_transparent_, "compact"_fl) );
+};
+
+TTS_CASE("Check settings(...).contains_only behavior")
+{
+  using namespace std::literals;
+  using namespace rbr::literals;
+
+  rbr::settings values( "kw1"_kw = 1,  "kw2"_kw = 1,  "kw3"_kw = 1 );
+
+  TTS_EXPECT    (values.contains_only("kw1"_kw,  "kw2"_kw,  "kw3"_kw)           );
+  TTS_EXPECT    (values.contains_only("kw1"_kw,  "kw3"_kw,  "kw2"_kw)           );
+  TTS_EXPECT    (values.contains_only("kw1"_kw,  "kw3"_kw,  "kw2"_kw, "xyz"_kw) );
+
+  TTS_EXPECT_NOT(values.contains_only("kw1"_kw,  "kw2"_kw));
+  TTS_EXPECT_NOT(values.contains_only("kw1"_kw)           );
+  TTS_EXPECT_NOT(values.contains_only("a"_kw)             );
+  TTS_EXPECT_NOT(values.contains_only("a"_kw, "b"_kw)     );
+};
+
+TTS_CASE("Check settings(...).contains_only constexpr behavior")
+{
+  using namespace std::literals;
+  using namespace rbr::literals;
+
+  constexpr rbr::settings values( "kw1"_kw = 1,  "kw2"_kw = 1,  "kw3"_kw = 1 );
+
+  TTS_CONSTEXPR_EXPECT(values.contains_only("kw1"_kw,  "kw2"_kw,  "kw3"_kw)           );
+  TTS_CONSTEXPR_EXPECT(values.contains_only("kw1"_kw,  "kw3"_kw,  "kw2"_kw)           );
+  TTS_CONSTEXPR_EXPECT(values.contains_only("kw1"_kw,  "kw3"_kw,  "kw2"_kw, "xyz"_kw) );
+
+  TTS_CONSTEXPR_EXPECT_NOT(values.contains_only("kw1"_kw,  "kw2"_kw));
+  TTS_CONSTEXPR_EXPECT_NOT(values.contains_only("kw1"_kw)           );
+  TTS_CONSTEXPR_EXPECT_NOT(values.contains_only("a"_kw)             );
+  TTS_CONSTEXPR_EXPECT_NOT(values.contains_only("a"_kw, "b"_kw)     );
+};
+
+TTS_CASE("Check settings(...).contains_none behavior")
+{
+  using namespace std::literals;
+  using namespace rbr::literals;
+
+  rbr::settings values( custom_ = foo {}, "surname"_kw = "john"s
+                      , value_ = 3.f, "aligned"_fl,is_transparent_
+                      );
+
+  TTS_EXPECT    (values.contains_none(is_modal_, "compact"_fl) );
+  TTS_EXPECT_NOT(values.contains_none(value_, is_transparent_) );
+};
+
+TTS_CASE("Check settings(...).contains_none constexpr behavior")
+{
+  using namespace std::literals;
+  using namespace rbr::literals;
+
+  constexpr rbr::settings values("custom"_kw = foo {}, value_ = 3.f, is_modal_);
+
+  TTS_CONSTEXPR_EXPECT    (values.contains_none(is_transparent_, "compact"_fl) );
+  TTS_CONSTEXPR_EXPECT_NOT(values.contains_none(value_) );
 };

--- a/test/raberu/get_type.cpp
+++ b/test/raberu/get_type.cpp
@@ -15,7 +15,7 @@ TTS_CASE("Check get_type<S,K> behavior")
   using namespace std::literals;
   using namespace rbr::literals;
 
-  auto values     = rbr::settings(coord_ = "Jane Doe"s, 42.69f, is_modal_);
+  auto values     = rbr::settings(coord_ = "Jane Doe"s, value_ = 42.69f, is_modal_);
   using options_t = decltype(values);
 
   TTS_TYPE_IS( (rbr::get_type_t<options_t, coord_   >), std::string      );
@@ -29,7 +29,7 @@ TTS_CASE("Check get_type<S,K,O> behavior")
   using namespace std::literals;
   using namespace rbr::literals;
 
-  auto values     = rbr::settings(coord_ = "Jane Doe"s, 42.69f, is_modal_);
+  auto values     = rbr::settings(coord_ = "Jane Doe"s, value_ = 42.69f, is_modal_);
   using options_t = decltype(values);
 
   TTS_TYPE_IS( (rbr::get_type_t<options_t, coord_   , void*>), std::string    );

--- a/test/raberu/interface.cpp
+++ b/test/raberu/interface.cpp
@@ -10,64 +10,65 @@
 #include <raberu.hpp>
 #include <tts/tts.hpp>
 
-template<typename... Vs>
-constexpr auto typed_interface(Vs const &...vs) noexcept
-{
-  rbr::settings s(vs...);
-  return s[rbr::keyword<int>] * s[rbr::keyword<double>];
-}
-
 constexpr auto
-named_interface(rbr::keyword_parameter auto const &...vs) noexcept
+named_interface(rbr::concepts::option auto const &...vs) noexcept
 {
   rbr::settings s(vs...);
-  return s[factor_] * s[ref_];
+  return s["level"_kw] * s[value_];
 }
 
-template<rbr::keyword_parameter... Vs>
+template<rbr::concepts::option... Vs>
+constexpr auto filtered_interface(Vs const &...vs) noexcept
+requires( rbr::settings<Vs...>::contains_any("level"_kw, value_) )
+{
+  rbr::settings s(vs...);
+  return s["level"_kw] * s[value_];
+}
+
+template<rbr::concepts::option... Vs>
 constexpr auto restricted_interface(Vs const &...vs) noexcept
-requires( rbr::match<Vs...>::with(factor_ | ref_ | is_modal_) )
+requires( rbr::settings<Vs...>::contains_only("level"_kw, value_) )
 {
   rbr::settings s(vs...);
-  return s[factor_] * s[ref_];
+  return s["level"_kw] * s[value_];
 }
-
-TTS_CASE("Check settings(...) as function interface with simple parameters")
-{
-  TTS_EQUAL(typed_interface(10, 3.41), 34.1);
-  TTS_EQUAL(typed_interface(3.41, 10), 34.1);
-};
 
 TTS_CASE("Check settings(...) as function interface with named parameters")
 {
-  TTS_EQUAL(named_interface(factor_ = 10, ref_ = 3.41), 34.1);
-  TTS_EQUAL(named_interface(ref_ = 3.41, factor_ = 10), 34.1);
-};
-
-TTS_CASE("Check settings(...) as function interface with restricted named parameters")
-{
-  TTS_EQUAL(restricted_interface(factor_ = 10, ref_ = 3.41), 34.1);
-  TTS_EQUAL(restricted_interface(ref_ = 3.41, factor_ = 10), 34.1);
-  TTS_EQUAL(restricted_interface(factor_ = 10, ref_ = 3.41, is_modal_), 34.1);
-  TTS_EQUAL(restricted_interface(factor_ = 10, is_modal_, ref_ = 3.41), 34.1);
-};
-
-TTS_CASE("Check settings(...) as constexpr function interface with simple parameters")
-{
-  TTS_CONSTEXPR_EQUAL(typed_interface(10, 3.41), 34.1);
-  TTS_CONSTEXPR_EQUAL(typed_interface(3.41, 10), 34.1);
+  TTS_EQUAL(named_interface("level"_kw = 10, value_ = 3.4f), 34.f);
+  TTS_EQUAL(named_interface(value_ = 3.4f, "level"_kw = 10), 34.f);
 };
 
 TTS_CASE("Check settings(...) as constexpr function interface with named parameters")
 {
-  TTS_CONSTEXPR_EQUAL(named_interface(factor_ = 10, ref_ = 3.41), 34.1);
-  TTS_CONSTEXPR_EQUAL(named_interface(ref_ = 3.41, factor_ = 10), 34.1);
+  TTS_CONSTEXPR_EQUAL(named_interface("level"_kw = 10, value_ = 3.4f), 34.f);
+  TTS_CONSTEXPR_EQUAL(named_interface(value_ = 3.4f, "level"_kw = 10), 34.f);
+};
+
+TTS_CASE("Check settings(...) as function interface with filtered named parameters")
+{
+  TTS_EQUAL(filtered_interface("level"_kw = 10, value_ = 3.4f), 34.f);
+  TTS_EQUAL(filtered_interface(value_ = 3.4f, "level"_kw = 10), 34.f);
+  TTS_EQUAL(filtered_interface("level"_kw = 10, value_ = 3.4f, is_modal_), 34.f);
+  TTS_EQUAL(filtered_interface("level"_kw = 10, is_modal_, value_ = 3.4f), 34.f);
+};
+
+TTS_CASE("Check settings(...) as constexpr function interface with filtered named parameters")
+{
+  TTS_CONSTEXPR_EQUAL(filtered_interface("level"_kw = 10, value_ = 3.4f), 34.f);
+  TTS_CONSTEXPR_EQUAL(filtered_interface(value_ = 3.4f, "level"_kw = 10), 34.f);
+  TTS_CONSTEXPR_EQUAL(filtered_interface("level"_kw = 10, value_ = 3.4f, is_modal_), 34.f);
+  TTS_CONSTEXPR_EQUAL(filtered_interface("level"_kw = 10, is_modal_, value_ = 3.4f), 34.f);
+};
+
+TTS_CASE("Check settings(...) as function interface with restricted named parameters")
+{
+  TTS_EQUAL(restricted_interface("level"_kw = 10, value_ = 3.4f), 34.f);
+  TTS_EQUAL(restricted_interface(value_ = 3.4f, "level"_kw = 10), 34.f);
 };
 
 TTS_CASE("Check settings(...) as constexpr function interface with restricted named parameters")
 {
-  TTS_CONSTEXPR_EQUAL(restricted_interface(factor_ = 10, ref_ = 3.41), 34.1);
-  TTS_CONSTEXPR_EQUAL(restricted_interface(ref_ = 3.41, factor_ = 10), 34.1);
-  TTS_CONSTEXPR_EQUAL(restricted_interface(factor_ = 10, ref_ = 3.41, is_modal_), 34.1);
-  TTS_CONSTEXPR_EQUAL(restricted_interface(factor_ = 10, is_modal_, ref_ = 3.41), 34.1);
+  TTS_CONSTEXPR_EQUAL(restricted_interface("level"_kw = 10, value_ = 3.4f), 34.f);
+  TTS_CONSTEXPR_EQUAL(restricted_interface(value_ = 3.4f, "level"_kw = 10), 34.f);
 };

--- a/test/raberu/merge.cpp
+++ b/test/raberu/merge.cpp
@@ -14,44 +14,42 @@ TTS_CASE("Check merge behavior: large defaults, few options")
 {
   using namespace std::literals;
 
-  auto defaults = rbr::settings(coord_ = "Jane Doe"s, factor_ = 42.69f, is_modal_);
-  auto opts     = rbr::settings(factor_ = 9567);
+  auto defaults = rbr::settings(coord_ = "Jane Doe"s, value_ = 42.69f, is_modal_);
+  auto opts     = rbr::settings(value_ = 956.7f);
 
   auto merged = rbr::merge(opts, defaults);
 
-  TTS_EQUAL(merged[factor_]   , 9567        );
-  TTS_EQUAL(merged[coord_]    , "Jane Doe"s );
-  TTS_EQUAL(merged[is_modal_] , true        );
+  TTS_EQUAL(merged[value_   ], 956.7f      );
+  TTS_EQUAL(merged[coord_   ], "Jane Doe"s );
+  TTS_EQUAL(merged[is_modal_], true        );
 
-  auto nopts     = rbr::settings(value_ = 9567);
-
+  auto nopts     = rbr::settings("other"_kw = 1234);
   auto merged2 = rbr::merge(nopts, defaults);
 
-  TTS_EQUAL(merged2[value_]    , 9567        );
-  TTS_EQUAL(merged2[factor_]   , 42.69f      );
-  TTS_EQUAL(merged2[coord_]    , "Jane Doe"s );
-  TTS_EQUAL(merged2[is_modal_] , true        );
+  TTS_EQUAL(merged2[value_]     , 42.69f      );
+  TTS_EQUAL(merged2["other"_kw] , 1234        );
+  TTS_EQUAL(merged2[coord_]     , "Jane Doe"s );
+  TTS_EQUAL(merged2[is_modal_]  , true        );
 };
 
 TTS_CASE("Check merge behavior: few defaults, large options")
 {
   using namespace std::literals;
 
-  auto opts     = rbr::settings(coord_ = "Jane Doe"s, factor_ = 42.69f, is_modal_);
-  auto defaults = rbr::settings(factor_ = 9567);
+  auto opts     = rbr::settings(coord_ = "Jane Doe"s, value_ = 42.69f, is_modal_);
+  auto defaults = rbr::settings(value_ = 956.7f);
 
   auto merged = rbr::merge(opts, defaults);
 
-  TTS_EQUAL(merged[factor_]   , 42.69f      );
-  TTS_EQUAL(merged[coord_]    , "Jane Doe"s );
-  TTS_EQUAL(merged[is_modal_] , true        );
+  TTS_EQUAL(merged[value_   ], 42.69f      );
+  TTS_EQUAL(merged[coord_   ], "Jane Doe"s );
+  TTS_EQUAL(merged[is_modal_], true        );
 
-  auto nopts     = rbr::settings(coord_ = "Jane Doe"s, value_ = 13.37, is_modal_);
+  auto ndefaults  = rbr::settings("other"_kw = 1234);
+  auto merged2    = rbr::merge( opts, ndefaults);
 
-  auto merged2 = rbr::merge(nopts, defaults);
-
-  TTS_EQUAL(merged2[factor_]   , 9567        );
-  TTS_EQUAL(merged2[value_]    , 13.37       );
-  TTS_EQUAL(merged2[coord_]    , "Jane Doe"s );
-  TTS_EQUAL(merged2[is_modal_] , true        );
+  TTS_EQUAL(merged2[value_]     , 42.69f      );
+  TTS_EQUAL(merged2["other"_kw] , 1234        );
+  TTS_EQUAL(merged2[coord_]     , "Jane Doe"s );
+  TTS_EQUAL(merged2[is_modal_]  , true        );
 };

--- a/test/raberu/size.cpp
+++ b/test/raberu/size.cpp
@@ -10,34 +10,16 @@
 #include <raberu.hpp>
 #include <tts/tts.hpp>
 
-TTS_CASE("Check settings(...) size - simple parameters")
-{
-  TTS_EQUAL(rbr::settings().size(), 0);
-  TTS_EQUAL(rbr::settings(1).size(), 1);
-  TTS_EQUAL(rbr::settings(2, 1.f).size(), 2);
-  TTS_EQUAL(rbr::settings("3", 2, 1.f).size(), 3);
-};
-
-TTS_CASE("Check settings(...) size - named parameters")
+TTS_CASE("Check settings(...) size")
 {
   using namespace std::literals;
   using namespace rbr::literals;
 
-  TTS_EQUAL(rbr::settings(custom_ = foo {}).size(), 1);
-  TTS_EQUAL(rbr::settings(custom_ = foo {}, value_ = 3.f).size(), 2);
-  TTS_EQUAL(rbr::settings(custom_ = foo {}, name_ = "john"s, value_ = 3.f).size(), 3);
-
   TTS_EQUAL(rbr::settings("custom"_kw = foo {}).size(), 1);
-  TTS_EQUAL(rbr::settings("custom"_kw = foo {}, "value"_kw = 3.f).size(), 2);
-  TTS_EQUAL(rbr::settings("custom"_kw = foo {}, "name"_kw = "john"s, "value"_kw = 3.f).size(), 3);
-};
+  TTS_EQUAL(rbr::settings("custom"_kw = foo {}, "border"_fl).size(), 2);
+  TTS_EQUAL(rbr::settings("custom"_kw = foo {}, "name"_kw = "john"s, "border"_fl).size(), 3);
 
-TTS_CASE("Check settings(...) constexpr size - simple parameters")
-{
-  TTS_CONSTEXPR_EQUAL(rbr::settings().size(), 0);
-  TTS_CONSTEXPR_EQUAL(rbr::settings(1).size(), 1);
-  TTS_CONSTEXPR_EQUAL(rbr::settings(2, 1.f).size(), 2);
-  TTS_CONSTEXPR_EQUAL(rbr::settings("3", 2, 1.f).size(), 3);
+  std::cout << rbr::settings("custom"_kw = foo {}, unroll<8>, "border"_fl) << "\n";
 };
 
 TTS_CASE("Check settings(...) constexpr size - named parameters")
@@ -45,12 +27,7 @@ TTS_CASE("Check settings(...) constexpr size - named parameters")
   using namespace std::literals;
   using namespace rbr::literals;
 
-  TTS_CONSTEXPR_EQUAL(rbr::settings(custom_ = foo {}).size(), 1);
-  TTS_CONSTEXPR_EQUAL(rbr::settings(custom_ = foo {}, value_ = 3.f).size(), 2);
-  TTS_CONSTEXPR_EQUAL(rbr::settings(custom_ = foo {}, coord_ = point {}, value_ = 3.f).size(), 3);
-
-  TTS_CONSTEXPR_EQUAL(rbr::settings("custom"_kw = foo {}).size(), 1);
-  TTS_CONSTEXPR_EQUAL(rbr::settings("custom"_kw = foo {}, "value"_kw = 3.f).size(), 2);
-  TTS_CONSTEXPR_EQUAL(
-      rbr::settings("custom"_kw = foo {}, "coord"_kw = point {}, "value"_kw = 3.f).size(), 3);
+  TTS_CONSTEXPR_EQUAL(rbr::settings("custom"_kw = foo{}).size(), 1);
+  TTS_CONSTEXPR_EQUAL(rbr::settings("custom"_kw = foo{}, "value"_kw = 3.f).size(), 2);
+  TTS_CONSTEXPR_EQUAL(rbr::settings("custom"_kw = foo{}, "coord"_kw = point{}, "value"_kw = 3.f).size(), 3);
 };


### PR DESCRIPTION
 - Cleaner concept separation between keyword, option, and settings
 - Shorter error message when something goes wrong handling settings
 - Checks for settings contents is simpler and richer
 - SLightly faster compile-time
 - NEW: settings can be streamed to an output stream
